### PR TITLE
force github runner to use py3.13

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
+    
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
@@ -38,6 +39,11 @@ jobs:
         if: env.AWS_CREDENTIALS_PRESENT == 'true'
         run: |
           echo "Your ARN is: $(aws sts get-caller-identity --query Arn --output text)"
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Deploy with SAM
         if: env.AWS_CREDENTIALS_PRESENT == 'true'


### PR DESCRIPTION
A simple addition to the Deploy github action for deploying that tells the github runner to use python3.13, when looking at documentation it says this is good practice anyways, and I believe it will solve our deploy issue.