### PR TITLE
add sql_docket_ingest lambda and update template

### DIFF
--- a/dev-env/lambda_functions/sql_docket_ingest/app.py
+++ b/dev-env/lambda_functions/sql_docket_ingest/app.py
@@ -1,0 +1,90 @@
+import psycopg
+import json
+import logger
+import boto3
+import os
+from botocore.exceptions import ClientError
+
+# def get_secret(secret_name):
+#     """
+#     Retrieve a secret from AWS Secrets Manager
+    
+#     Args:
+#         secret_name: Name of the secret to retrieve
+        
+#     Returns:
+#         dict: The secret key/value pairs
+#     """
+#     region_name = os.environ.get('AWS_REGION', 'us-east-1')
+    
+#     # Create a Secrets Manager client
+#     session = boto3.session.Session()
+#     client = session.client(
+#         service_name='secretsmanager',
+#         region_name=region_name
+#     )
+    
+#     try:
+#         # Get the secret value
+#         response = client.get_secret_value(SecretId=secret_name)
+        
+#         # Decode and parse the secret string JSON
+#         if 'SecretString' in response:
+#             secret = json.loads(response['SecretString'])
+#             return secret
+#         else:
+#             logger.error("Secret not found in expected format")
+#             raise Exception("Secret not found in expected format")
+            
+#     except ClientError as e:
+#         logger.error(f"Error retrieving secret: {str(e)}")
+#         raise e
+
+def handler(event, context):
+    """
+    Lambda handler that processes data from another Lambda invocation
+    and stores it in a PostgreSQL database.
+    
+    Args:
+        event (dict): Contains the payload from the invoking Lambda
+        context: Lambda context object
+    """
+    logger.info("Received event: %s", json.dumps(event))
+    
+    # try:
+    #     # Extract data from the event
+    #     # If the event comes from a direct Lambda invocation, it will be the payload you provided
+    #     # If it comes from an S3 event or other service, structure will be different
+    #     if 'Records' in event:
+    #         # Handle S3 or SQS type events
+    #         logger.info("Processing event with Records")
+    #         # Example: data = process_records(event['Records'])
+    #         data = event['Records']
+    #         print(data)
+    #     else:
+    #         # Handle direct Lambda invocations
+    #         logger.info("Processing direct Lambda invocation")
+    #         data = event
+        
+        # Connect to the PostgreSQL database
+    #     # Use environment variables for connection details
+    #     conn = get_db_connection()
+        
+    #     # Process data and insert into database
+    #     result = insert_data_to_db(conn, data)
+        
+    #     # Close the connection
+    #     conn.close()
+        
+    #     return {
+    #         'statusCode': 200,
+    #         'body': json.dumps({'message': 'Data processed successfully', 'result': result})
+    #     }
+        
+    # except Exception as e:
+    #     logger.error(f"Error processing event: {str(e)}")
+    #     return {
+    #         'statusCode': 500,
+    #         'body': json.dumps({'error': str(e)})
+    #     }
+    return 0

--- a/dev-env/lambda_functions/sql_docket_ingest/requirements.txt
+++ b/dev-env/lambda_functions/sql_docket_ingest/requirements.txt
@@ -1,0 +1,1 @@
+psycopg[binary]

--- a/dev-env/template.yaml
+++ b/dev-env/template.yaml
@@ -4,6 +4,12 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   AWS SAM Template for Multi-Lambda Microservices
 
+Parameters:
+  ExistingBucketName:
+    Type: String
+    Description: Name of the existing S3 bucket that will trigger the Orchestrator Lambda
+    Default: "etllambdatest"
+
 Globals:
   Function:
     Timeout: 10
@@ -21,41 +27,41 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - S3ReadPolicy:  # Allows this Lambda to read from S3
-            BucketName: !Ref ExistingDataBucket
+            BucketName: !Ref ExistingBucketName
+        - Statement:  # Add this to allow invoking other Lambdas
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource: !GetAtt SQLDocketIngestFunction.Arn
       Events:
         S3PutEvent:
           Type: S3
           Properties:
-            Bucket: !Ref ExistingDataBucket
+            Bucket: !Ref ExistingBucketName
             Events: s3:ObjectCreated:*
 
-  # # SQL Ingest Lambda (Triggered by Orchestrator)
-  # SQLIngestFunction:
-  #   Type: AWS::Serverless::Function
-  #   Properties:
-  #     CodeUri: lambda_functions/sql_ingest/
-  #     Handler: app.handler
-  #     Runtime: python3.13
-  #     Policies:
-  #       - AWSLambdaBasicExecutionRole
-  #       - AmazonRDSDataFullAccess  # Allows writing to Aurora
-  #     Environment:
-  #       Variables:
-  #         AURORA_CLUSTER_ARN: "arn:aws:rds:us-east-1:123456789012:cluster:my-cluster"
-  #         AURORA_SECRET_ARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"
-  #     Events:
-  #       OrchestratorTrigger:
-  #         Type: EventBridgeRule
-  #         Properties:
-  #           Pattern:
-  #             source:
-  #               - "custom.orchestrator"
-
-  # Use Existing S3 Bucket (Instead of Creating One)
-  ExistingDataBucket:
-    Type: AWS::S3::Bucket
+  # SQL Docket Ingest Lambda (Triggered by Orchestrator)
+  SQLDocketIngestFunction:
+    Type: AWS::Serverless::Function
     Properties:
-      BucketName: "your-existing-bucket-name" 
+      CodeUri: lambda_functions/sql_docket_ingest/
+      Handler: app.handler
+      Runtime: python3.13
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AmazonRDSDataFullAccess  # Allows writing to Aurora
+        - Version: '2012-10-17'  # Add Secrets Manager permissions
+          Statement:
+            - Effect: Allow
+              Action:
+                - secretsmanager:GetSecretValue
+              Resource: "arn:aws:secretsmanager:us-east-1:936771282063:secret:mirrulationsdb/postgres/master-uA4mKl"  
+      Environment:
+        Variables:
+          # Remove or replace these with your DB_SECRET_NAME environment variable
+          # AURORA_CLUSTER_ARN: "arn:aws:rds:us-east-1:123456789012:cluster:my-cluster"
+          # AURORA_SECRET_ARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"
+          # DB_SECRET_NAME: "your-database-secret-name"  # Name of your secret in Secrets Manager
 
 Outputs:
 
@@ -63,6 +69,6 @@ Outputs:
     Description: "Orchestrator Lambda Function ARN"
     Value: !GetAtt OrchestratorFunction.Arn
 
-  # SQLIngestFunctionArn:
-  #   Description: "Data Ingestor Lambda Function ARN"
-  #   Value: !GetAtt DataIngestorFunction.Arn
+  SQLDocketIngestFunctionArn:
+      Description: "SQL Docket Ingest Lambda Function ARN"
+      Value: !GetAtt SQLDocketIngestFunction.Arn


### PR DESCRIPTION
This commit adds all the necessary files for the sql_docket_ingest lambda function, however usability is still basic. Functional code should be added/modified to ensure it connects appropriately with the database, however the secrets access should be set up in template.yaml. In addition, the template yaml has the new function added so sam build will recognize the new lambda.