### PR TITLE
set secrets endpoint to private-dns

### DIFF
--- a/dev-env/template.yaml
+++ b/dev-env/template.yaml
@@ -43,6 +43,7 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${AWS::Region}.secretsmanager"
       VpcId: !Ref VpcId
       VpcEndpointType: Interface
+      PrivateDnsEnabled: true
       SecurityGroupIds:
         - sg-03e2bf8d3930f3c42
       SubnetIds:


### PR DESCRIPTION
This seems to be be the solution to the secrets manager issue, apparently the DNS has to be private if we are trying to route through the endpoint to secretsmanager.