### PR TITLE
move secrets getting and db connection to common layer to reduce dupes

### DIFF
--- a/dev-env/common_layer/python/common/utils/secrets.py
+++ b/dev-env/common_layer/python/common/utils/secrets.py
@@ -1,0 +1,38 @@
+import os
+import json
+import boto3
+from botocore.exceptions import ClientError
+
+def get_secret(secret_name):
+    """
+    Retrieve a secret from AWS Secrets Manager
+    Args:
+        secret_name: Name of the secret to retrieve
+    Returns:
+        dict: The secret key/value pairs
+    """
+    region_name = os.environ.get('AWS_REGION', 'us-east-1')
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    try:
+        # Get the secret value
+        response = client.get_secret_value(SecretId=secret_name)
+        print(response)
+
+        # Decode and parse the secret string JSON
+        if 'SecretString' in response:
+            secret = json.loads(response['SecretString'])
+            return secret
+        else:
+            print("Secret not found in expected format")
+            raise Exception("Secret not found in expected format")
+
+    except ClientError as e:
+        print(f"Error retrieving secret: {str(e)}")
+        raise e

--- a/dev-env/common_layer/python/common/utils/sql.py
+++ b/dev-env/common_layer/python/common/utils/sql.py
@@ -1,18 +1,18 @@
 import psycopg
 import os
+from common.utils.secrets import get_secret
+
 def connect():
-    dbname = os.getenv("POSTGRES_DB")
-    username = os.getenv("POSTGRES_USER")
-    password = os.getenv("POSTGRES_PASSWORD")
-    host = os.getenv("POSTGRES_HOST")
-    port = os.getenv("POSTGRES_PORT")
+
+    secret_name = os.environ.get('DB_SECRET_NAME')
+    secret = get_secret(secret_name)
 
     conn_params = {
-        "dbname": dbname,
-        "user": username,
-        "password": password,
-        "host": host,
-        "port": port,
+        "dbname": secret['db'],
+        "user": secret['username'],
+        "password": secret['password'],
+        "host": secret['host'],
+        "port": secret['port'],
     }
 
     conn = psycopg.connect(**conn_params)

--- a/dev-env/lambda_functions/sql_docket_ingest/app.py
+++ b/dev-env/lambda_functions/sql_docket_ingest/app.py
@@ -1,57 +1,7 @@
 import json
 import os
-import psycopg
 import boto3
-from botocore.exceptions import ClientError
 from common.ingest import ingest_docket
-
-def get_secret(secret_name):
-    """
-    Retrieve a secret from AWS Secrets Manager
-    Args:
-        secret_name: Name of the secret to retrieve
-    Returns:
-        dict: The secret key/value pairs
-    """
-    region_name = os.environ.get('AWS_REGION', 'us-east-1')
-
-    # Create a Secrets Manager client
-    session = boto3.session.Session()
-    client = session.client(
-        service_name='secretsmanager',
-        region_name=region_name
-    )
-
-    try:
-        # Get the secret value
-        response = client.get_secret_value(SecretId=secret_name)
-        print(response)
-
-        # Decode and parse the secret string JSON
-        if 'SecretString' in response:
-            secret = json.loads(response['SecretString'])
-            return secret
-        else:
-            print("Secret not found in expected format")
-            raise Exception("Secret not found in expected format")
-
-    except ClientError as e:
-        print(f"Error retrieving secret: {str(e)}")
-        raise e
-    
-def get_db_connection():
-    """
-    Retrieve a connection to the PostgreSQL database
-    """
-    secret_name = os.environ.get('DB_SECRET_NAME')
-    secret = get_secret(secret_name)
-
-    os.putenv("POSTGRES_HOST",secret['host'])
-    os.putenv("POSTGRES_PORT",secret['port'])
-    os.putenv("POSTGRES_DB",secret['db'])
-    os.putenv("POSTGRES_USER",secret['username'])
-    os.putenv("POSTGRES_PASSWORD",secret['password'])
-
 
 def handler(event, context):
     """
@@ -63,7 +13,6 @@ def handler(event, context):
         context: Lambda context object
     """
     print(f"Received event: {json.dumps(event)}")
-
 
     
     try:
@@ -82,8 +31,6 @@ def handler(event, context):
 
         if 'docket' in s3dict['file_key']:
             #set environment variables
-            print("getting db connection")
-            get_db_connection()
             print("ingesting")
             ingest_docket(file_content)
             print("ingest complete!")


### PR DESCRIPTION
This PR moves get_secret and get_db_connection to the common layer so we don't need to change them in every lambda if there is something that needs to be modified. In addition, having these in the common layer allows the secrets to be gotten when the lambda functions are created, hopefully reducing runtime.