### PR TITLE
Test Changes

### DIFF
--- a/dev-env/conftest.py
+++ b/dev-env/conftest.py
@@ -1,0 +1,8 @@
+import sys
+import os
+
+# Adjust the path so Python can find the 'common' package.
+# This assumes your conftest.py is in the dev-env directory.
+layer_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "./common_layer/python"))
+if layer_path not in sys.path:
+    sys.path.insert(0, layer_path)

--- a/dev-env/lambda_functions/orchestrator/app.py
+++ b/dev-env/lambda_functions/orchestrator/app.py
@@ -49,7 +49,7 @@ def orch_lambda(event, context):
             response = lambda_client.invoke(
                 FunctionName=sql_docket_function,
                 InvocationType='RequestResponse',
-                Payload=json.dumps(s3dict)
+                Payload=json.dumps(s3dict).encode('utf-8')
             )
             return {
                 'statusCode': 200,
@@ -61,7 +61,7 @@ def orch_lambda(event, context):
             response = lambda_client.invoke(
                 FunctionName=sql_document_function,
                 InvocationType='RequestResponse',
-                Payload=json.dumps(s3dict) 
+                Payload=json.dumps(s3dict)
             )
             return {
                 'statusCode': 200,

--- a/dev-env/tests/orchestrator/test_app.py
+++ b/dev-env/tests/orchestrator/test_app.py
@@ -16,7 +16,9 @@ def aws_credentials():
         'AWS_SECRET_ACCESS_KEY': 'testing',
         'AWS_SECURITY_TOKEN': 'testing',
         'AWS_SESSION_TOKEN': 'testing',
-        'AWS_DEFAULT_REGION': 'us-east-1'
+        'AWS_DEFAULT_REGION': 'us-east-1',
+        'SQL_DOCKET_INGEST_FUNCTION': 'SQLDocketIngestFunction',
+        'SQL_DOCUMENT_INGEST_FUNCTION': 'SQLDocumentIngestFunction'
     }):
         yield
 
@@ -39,7 +41,10 @@ def test_extractS3_valid_event():
     }
     
     result = extractS3(event)
-    assert result == 's3://test-bucket/path/to/docket_file.json'
+    assert result == {
+        "bucket": "test-bucket",
+        "file_key": "path/to/docket_file.json"
+    }
 
 def test_extractS3_empty_event():
     """Test extractS3 with an empty event"""
@@ -85,7 +90,7 @@ def test_orch_lambda_docket_json(aws_credentials):
     }
     
     # Mock the lambda client invoke method
-    with patch('boto3.client') as mock_boto:
+    with patch('lambda_functions.orchestrator.app.boto3.client') as mock_boto:
         mock_lambda = mock_boto.return_value
         mock_lambda.invoke.return_value = {'StatusCode': 200}
         
@@ -94,10 +99,16 @@ def test_orch_lambda_docket_json(aws_credentials):
         
         # Verify lambda was called correctly
         mock_boto.assert_called_once_with('lambda')
+        expected_payload = json.dumps({
+            "s3dict": {
+                "bucket": "test-bucket",
+                "file_key": "path/to/docket_file.json"
+            }
+        }).encode("utf-8")
         mock_lambda.invoke.assert_called_once_with(
             FunctionName='SQLDocketIngestFunction',
             InvocationType='RequestResponse',
-            Payload=json.dumps({"file_path": 's3://test-bucket/path/to/docket_file.json'}).encode("utf-8")
+            Payload=expected_payload
         )
         
     # Verify the result
@@ -137,9 +148,9 @@ def test_orch_lambda_non_docket_file(aws_credentials):
     
     # Verify the result
     assert result['statusCode'] == 200
-    assert 'File not processed - not a docket JSON file' in result['body']
+    assert 'File not processed' in result['body']
 
-def test_orch_lambda_invalid_event():
+def test_orch_lambda_invalid_event(aws_credentials):
     """Test orch_lambda with an invalid event"""
     # Call the function with an empty event
     result = orch_lambda({}, {})
@@ -148,7 +159,7 @@ def test_orch_lambda_invalid_event():
     assert result['statusCode'] == 400
     assert 'Error processing request' in result['body']
 
-def test_orch_lambda_exception():
+def test_orch_lambda_exception(aws_credentials):
     """Test orch_lambda with an exception being raised"""
     # Create a sample S3 event
     event = {

--- a/dev-env/tests/orchestrator/test_app.py
+++ b/dev-env/tests/orchestrator/test_app.py
@@ -100,10 +100,8 @@ def test_orch_lambda_docket_json(aws_credentials):
         # Verify lambda was called correctly
         mock_boto.assert_called_once_with('lambda')
         expected_payload = json.dumps({
-            "s3dict": {
                 "bucket": "test-bucket",
                 "file_key": "path/to/docket_file.json"
-            }
         }).encode("utf-8")
         mock_lambda.invoke.assert_called_once_with(
             FunctionName='SQLDocketIngestFunction',

--- a/dev-env/tests/sql_ingest/test_app.py
+++ b/dev-env/tests/sql_ingest/test_app.py
@@ -78,7 +78,7 @@ def test_handler_with_docket_file(mock_s3_bucket, sample_docket_json):
     }
     
     # Mock the ingest_docket function
-    with patch('lambda_functions.sql_docket_ingest.app.ingest_docket') as mock_ingest:
+    with patch('common.ingest.ingest_docket') as mock_ingest:
         # Execute the handler
         response = handler(event, {})
         


### PR DESCRIPTION
Adds a few fixes to the tests, the orchestrator was still testing the lambda payload as the old file path method instead of an s3obj dictionary, so that was fixed. In addition, I added a path to the common folder to have pytest recognize it as a library. I made the orchestrator payload convert to bytes before triggering the invoke.