### PR TITLE
clean up template, add SNS trigger

### DIFF
--- a/dev-env/template.yaml
+++ b/dev-env/template.yaml
@@ -4,12 +4,6 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   AWS SAM Template for Multi-Lambda Microservices
 
-# Parameters:
-#   ExistingBucketName:
-#     Type: String
-#     Description: Name of the existing S3 bucket that will trigger the Orchestrator Lambda
-#     Default: "etllambdatest"
-
 Globals:
   Function:
     Timeout: 120
@@ -24,7 +18,6 @@ Parameters:
     Type: CommaDelimitedList
     Description: "Route table IDs for the private subnets"
     Default: "rtb-0c89919b1ec9ba6e1"
-  
 
 Resources:
   # VPC Endpoint for S3
@@ -58,9 +51,9 @@ Resources:
   OrchestratorBucket:
     Type: AWS::S3::Bucket
     Properties:
-      # This example uses a generated bucket name. Adjust as needed.
       BucketName: !Sub "orchestrator-bucket-${AWS::AccountId}-${AWS::Region}"
 
+  # A common layer for shared code across lambdas such as secrets manager info
   CommonLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
@@ -70,7 +63,7 @@ Resources:
       CompatibleRuntimes:
         - python3.13
 
-  # Orchestrator Lambda (Triggered by S3 PutObject)
+  # Orchestrator Lambda (Triggered by SNS notification of S3 PutObject)
   OrchestratorFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -81,7 +74,6 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - S3ReadPolicy:  # Allows this Lambda to read from S3
-            # BucketName: !Ref OrchestratorBucket #ExistingBucketName
             BucketName: !Sub "orchestrator-bucket-${AWS::AccountId}-${AWS::Region}"
         - Statement:  # Add this to allow invoking other Lambdas
           - Effect: Allow
@@ -91,7 +83,6 @@ Resources:
               - !GetAtt SQLDocketIngestFunction.Arn
               - !GetAtt SQLDocumentIngestFunction.Arn
               - !GetAtt OpenSearchCommentFunction.Arn
-          
       Events:
         S3PutEvent:
           Type: S3
@@ -113,98 +104,14 @@ Resources:
       # The external SNS topic ARN (from the external account)
       SourceArn: arn:aws:sns:us-east-1:533267155325:mirrulations-object_created
 
-  # # Permission to allow S3 to invoke the Lambda
-  # OrchestratorFunctionS3Permission:
-  #   Type: AWS::Lambda::Permission
+  # Uncomment this if you want to create an SNS subscription for the Orchestrator Lambda to Mirrulations SNS topic
+  
+  # OrchestratorSNSSubscription:
+  #   Type: AWS::SNS::Subscription
   #   Properties:
-  #     Action: lambda:InvokeFunction
-  #     FunctionName: !Ref OrchestratorFunction
-  #     Principal: s3.amazonaws.com
-  #     SourceAccount: !Ref AWS::AccountId
-  #     SourceArn: !Sub "arn:aws:s3:::${ExistingBucketName}"
-
-  # # Custom resource Lambda to set up S3 notifications
-  # S3NotificationSetupFunction:
-  #   Type: AWS::Serverless::Function
-  #   Properties:
-  #     Handler: index.handler
-  #     Runtime: python3.13
-  #     InlineCode: |
-  #       import boto3
-  #       import cfnresponse
-  #       import json
-  #       import logging
-
-  #       logger = logging.getLogger()
-  #       logger.setLevel(logging.INFO)
-
-  #       def handler(event, context):
-  #           logger.info('Received event: %s', json.dumps(event))
-            
-  #           # Extract parameters from the event
-  #           props = event['ResourceProperties']
-  #           bucket_name = props['BucketName']
-  #           lambda_arn = props['LambdaArn']
-            
-  #           response_data = {}
-  #           physical_id = f"{bucket_name}-notification"
-            
-  #           try:
-  #               if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
-  #                   logger.info(f"Configuring notification for bucket {bucket_name} to Lambda {lambda_arn}")
-                    
-  #                   # Create S3 client
-  #                   s3 = boto3.client('s3')
-                    
-  #                   # Configure bucket notification
-  #                   notification_config = {
-  #                       'LambdaFunctionConfigurations': [
-  #                           {
-  #                               'LambdaFunctionArn': lambda_arn,
-  #                               'Events': ['s3:ObjectCreated:*']
-  #                           }
-  #                       ]
-  #                   }
-                    
-  #                   # Apply the notification configuration
-  #                   s3.put_bucket_notification_configuration(
-  #                       Bucket=bucket_name,
-  #                       NotificationConfiguration=notification_config
-  #                   )
-                    
-  #                   response_data['Message'] = f"Successfully configured notification for {bucket_name}"
-  #                   cfnresponse.send(event, context, cfnresponse.SUCCESS, response_data, physical_id)
-  #               elif event['RequestType'] == 'Delete':
-  #                   # Remove the notification configuration
-  #                   logger.info(f"Removing notification for bucket {bucket_name}")
-                    
-  #                   s3 = boto3.client('s3')
-  #                   s3.put_bucket_notification_configuration(
-  #                       Bucket=bucket_name,
-  #                       NotificationConfiguration={}
-  #                   )
-                    
-  #                   response_data['Message'] = f"Successfully removed notification for {bucket_name}"
-  #                   cfnresponse.send(event, context, cfnresponse.SUCCESS, response_data, physical_id)
-  #           except Exception as e:
-  #               logger.error('Error: %s', str(e))
-  #               cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)}, physical_id)
-  #     Policies:
-  #       - Version: '2012-10-17'
-  #         Statement:
-  #           - Effect: Allow
-  #             Action:
-  #               - 's3:PutBucketNotification'
-  #               - 's3:GetBucketNotification'
-  #             Resource: !Sub "arn:aws:s3:::${ExistingBucketName}"
-
-  # # Custom resource to trigger the notification configuration
-  # S3NotificationConfig:
-  #   Type: Custom::S3BucketNotification
-  #   Properties:
-  #     ServiceToken: !GetAtt S3NotificationSetupFunction.Arn
-  #     BucketName: !Ref ExistingBucketName
-  #     LambdaArn: !GetAtt OrchestratorFunction.Arn
+  #     TopicArn: arn:aws:sns:us-east-1:533267155325:mirrulations-object_created
+  #     Protocol: lambda
+  #     Endpoint: !GetAtt OrchestratorFunction.Arn
 
   # SQL Docket Ingest Lambda (Triggered by Orchestrator)
   SQLDocketIngestFunction:
@@ -230,7 +137,6 @@ Resources:
       # Role: arn:aws:iam::936771282063:role/334s25_lambda_execution_opensearch
       Policies:
         - AmazonS3ReadOnlyAccess  # Allows reading from S3
-        
         - AWSLambdaBasicExecutionRole
         - AmazonRDSDataFullAccess  # Allows writing to Aurora
         - Version: '2012-10-17'  # Add Secrets Manager permissions
@@ -241,11 +147,7 @@ Resources:
               Resource: "arn:aws:secretsmanager:us-east-1:936771282063:secret:mirrulationsdb/postgres/master-uA4mKl"  
       Environment:
         Variables:
-          # Remove or replace these with your DB_SECRET_NAME environment variable
-          # AURORA_CLUSTER_ARN: "arn:aws:rds:us-east-1:123456789012:cluster:my-cluster"
-          # AURORA_SECRET_ARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"
           DB_SECRET_NAME: "mirrulationsdb/postgres/master"  # Name of your secret in Secrets Manager
-
 
   # SQL Docket Ingest Lambda (Triggered by Orchestrator)
   SQLDocumentIngestFunction:
@@ -281,14 +183,8 @@ Resources:
               Resource: "arn:aws:secretsmanager:us-east-1:936771282063:secret:mirrulationsdb/postgres/master-uA4mKl"  
       Environment:
         Variables:
-          # Remove or replace these with your DB_SECRET_NAME environment variable
-          # AURORA_CLUSTER_ARN: "arn:aws:rds:us-east-1:123456789012:cluster:my-cluster"
-          # AURORA_SECRET_ARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"
           DB_SECRET_NAME: "mirrulationsdb/postgres/master"  # Name of your secret in Secrets Manager
 
-
-
-  # I am assuming the congifuration for the OpenSearchCommentFunction is very similar to the SQLDocketIngestFunction.
   OpenSearchCommentFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -311,20 +207,9 @@ Resources:
         - arn:aws:lambda:us-east-1:936771282063:layer:aoss-imports:2
         - !Ref CommonLayer
       Role: arn:aws:iam::936771282063:role/334s25_lambda_execution_opensearch
-      # Policies:
-      #   - AmazonS3ReadOnlyAccess  # Allows reading from S3
-      #   - AWSLambdaBasicExecutionRole
-
-      #   - Version: '2012-10-17'  # Add Secrets Manager permissions
-      #     Statement:
-      #       - Effect: Allow
-      #         Action:
-      #           - secretsmanager:GetSecretValue
-      #         Resource: "arn:aws:secretsmanager:us-east-1:936771282063:secret:mirrulationsdb/opensearch/master-7xJt7C"
       Environment:
         Variables:
           DB_SECRET_NAME: "mirrulationsdb/opensearch/master"  # Name of the secret in Secrets Manager
-
 
 Outputs:
 


### PR DESCRIPTION
This PR adds the code for an SNS trigger in the lambda template instead of manually adding it in the aws web interface. Also, cleans up some useless commented code and odd spacing.