### PR TITLE
Update tests

### DIFF
--- a/dev-env/tests/orchestrator/test_app.py
+++ b/dev-env/tests/orchestrator/test_app.py
@@ -19,7 +19,8 @@ def aws_credentials():
         'AWS_DEFAULT_REGION': 'us-east-1',
         'SQL_DOCKET_INGEST_FUNCTION': 'SQLDocketIngestFunction',
         'SQL_DOCUMENT_INGEST_FUNCTION': 'SQLDocumentIngestFunction',
-        'OPENSEARCH_INGEST_FUNCTION': 'OpenSearchIngestFunction',
+        'OPENSEARCH_COMMENT_INGEST_FUNCTION': 'OpenSearchCommentIngestFunction',
+        'OPENSEARCH_TEXT_EXTRACT_FUNCTION': 'OpenSearchTextExtractFunction',
         'HTM_SUMMARY_INGEST_FUNCTION': 'HTMSummaryIngestFunction',
     }):
         yield


### PR DESCRIPTION
This PR fixes the failing orchestrator tests (we hadn't added the env variable for the new pdf extractor lambda), as well as fixed up the new htm lambda tests. The test for htm lambda wasn't mocking the ingest script and therefore it was trying to actually run it, which was causing the issues. Also, the file_path in the test seemed to be wrong and I know we were talking about that yesterday so I added raw-data/ to the beggining of each of them.