### PR TITLE
remove variables from sql comment ingest

### DIFF
--- a/dev-env/template.yaml
+++ b/dev-env/template.yaml
@@ -237,11 +237,6 @@ Resources:
       Environment:
         Variables:
           DB_SECRET_NAME: "mirrulationsdb/postgres/master"  # Name of your secret in Secrets Manager
-          POSTGRES_PORT: null
-          POSTGRES_DB: null
-          POSTGRES_PASSWORD: null
-          POSTGRES_HOST: null
-          POSTGRES_USER: null
 
 # SQL HTM Summary Ingest Lambda (Triggered by Orchestrator)
   HTMSummaryIngestFunction:


### PR DESCRIPTION
This PR removes the global variables we previously added to sql comment ingest, there is a new strategy that works better and is cleaner. (also, apparently null values fail in production but pass sam validate)