### PR TITLE
increase extrator timeout

### DIFF
--- a/dev-env/template.yaml
+++ b/dev-env/template.yaml
@@ -305,6 +305,7 @@ Resources:
       CodeUri: lambda_functions/pdf_text_extract/
       Handler: app.handler
       Runtime: python3.13
+      Timeout: 180
       VpcConfig:
         SecurityGroupIds:
           - sg-03e2bf8d3930f3c42


### PR DESCRIPTION
Extends the pdf extraction lambda timeout to be 180 seconds instead of 120. Hopefully this can allow for bigger files to be extracted without going too long still.